### PR TITLE
Fix typo in GitHub's "raw" subdomain

### DIFF
--- a/issue-295.md
+++ b/issue-295.md
@@ -72,4 +72,4 @@ It is possible to provide some additional mitigatation by encrypting the Session
 
 ### Candidate Design
 
-![](https://raw2.github.com/earlchew/mosh/issues/295/dev/issue-295/moshd-overview.png)
+![](https://raw.github.com/earlchew/mosh/issues/295/dev/issue-295/moshd-overview.png)


### PR DESCRIPTION
This error has been noted already in a comment left on [keithw#295](https://github.com/keithw/mosh/issues/295#issuecomment-66917912).
